### PR TITLE
v0.3.0 - migrate towards client approach

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ pubspec.lock
 
 build/
 
-.flutter-plugins-dependencies
+.flutter-plugins*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.3.0
+- Begin migration towards client approach, there is now `AuthClient` which can be supplied as a http client
+
 ## 0.2.4
 - Auth Manager no longer has an awkward config validation in the constructor
 

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -187,7 +187,7 @@ class AuthClient extends http.BaseClient {
   void handleResponse(http.Response response) {
     var headers = response.headers;
     String? accessToken = headers['access-token'];
-    if (accessToken == "") return;
+    if (accessToken?.isEmpty ?? true) return;
     authManager.user!.accessToken = accessToken;
     authManager.user!.client = headers['client'];
     authManager.user!.uid = headers['uid'];
@@ -196,7 +196,9 @@ class AuthClient extends http.BaseClient {
 
   User? handleUserResponse(http.Response response) {
     if (response.statusCode != 200) {
-      throw Exception('Failed to login');
+      throw Exception(
+        'Failed to login. Status code: ${response.statusCode}. Body: ${response.body}',
+      );
     }
     var respHeaders = response.headers;
     var body = json.decode(response.body);
@@ -225,13 +227,16 @@ class AuthClient extends http.BaseClient {
 
   bool userMustBeLoggedIn() {
     if (user == null || user!.accessToken == null) {
-      throw Exception('User not logged in');
+      throw Exception('User must be logged in to make this request');
     }
     return true;
   }
 
   Uri addAppToUrl(Uri url, {Map<String, dynamic>? queryParams}) {
     final Map<String, String> paramsToAdd = {};
+    if (url.queryParameters.isNotEmpty) {
+      paramsToAdd.addAll(url.queryParameters);
+    }
     if (queryParams != null) {
       queryParams.forEach((key, value) {
         paramsToAdd[key] = value.toString();

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -1,0 +1,248 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+import 'auth_config.dart';
+import 'auth_manager.dart';
+import 'user.dart';
+
+class AuthClient extends http.BaseClient {
+  final http.Client _httpClient;
+  final AuthConfig config;
+  final AuthManager authManager;
+
+  AuthClient({required this.config, http.Client? httpClient})
+    : _httpClient = httpClient ?? http.Client(),
+      authManager = AuthManager(config: config) {
+    authManager.httpClient = this;
+  }
+
+  Future<User?> login(String email, String password) async {
+    var response = await _sendUnstreamed(
+      'POST',
+      config.signInUrl,
+      defaultHeaders,
+      jsonEncode({'email': email, 'password': password}),
+      null,
+      skipUserValidation: true,
+    );
+    return handleUserResponse(response);
+  }
+
+  Future<void> logout() async {
+    await delete(config.signOutUrl);
+    await authManager.clear();
+  }
+
+  Future<User?> changePassword({required String password}) async {
+    var response = await put(
+      config.passwordUrl,
+      headers: defaultHeaders,
+      body: jsonEncode({
+        'password': password,
+        'password_confirmation': password,
+      }),
+    );
+    return handleUserResponse(response);
+  }
+
+  Future<User?> createAccount({
+    required String email,
+    required String password,
+    required String name,
+  }) async {
+    var response = await post(
+      config.createAccountUrl,
+      body: jsonEncode({
+        'email': email,
+        'password': password,
+        'password_confirmation': password,
+        'name': name,
+      }),
+    );
+    return handleUserResponse(response);
+  }
+
+  Future<bool> validateToken() async {
+    if (user == null || user!.accessToken == null) {
+      return false;
+    }
+    var response = await get(config.validateTokenUrl);
+    if (response.statusCode != 200) {
+      return false;
+    }
+    handleResponse(response);
+    return true;
+  }
+
+  @override
+  Future<http.StreamedResponse> send(
+    http.BaseRequest request, {
+    bool skipUserValidation = false,
+  }) async {
+    if (!skipUserValidation) request.headers.addAll(authHeaders());
+    return _httpClient.send(request);
+  }
+
+  @override
+  Future<http.Response> head(Uri url, {Map<String, String>? headers}) =>
+      _sendUnstreamed(
+        'HEAD',
+        url,
+        headers,
+        null,
+        null,
+        skipUserValidation: true,
+      );
+
+  @override
+  Future<http.Response> get(Uri url, {Map<String, String>? headers}) =>
+      _sendUnstreamed('GET', url, headers, null, null);
+
+  Future<http.Response> getWithParams(
+    Uri url, {
+    Map<String, String>? headers,
+    Map<String, dynamic>? queryParams,
+  }) async {
+    url = _validate(url);
+    final urlToSend = addAppToUrl(url, queryParams: queryParams);
+    return get(urlToSend, headers: headers);
+  }
+
+  @override
+  Future<http.Response> post(
+    Uri url, {
+    Map<String, String>? headers,
+    Object? body,
+    Encoding? encoding,
+  }) => _sendUnstreamed('POST', url, headers, body, encoding);
+
+  @override
+  Future<http.Response> put(
+    Uri url, {
+    Map<String, String>? headers,
+    Object? body,
+    Encoding? encoding,
+  }) => _sendUnstreamed('PUT', url, headers, body, encoding);
+
+  @override
+  Future<http.Response> patch(
+    Uri url, {
+    Map<String, String>? headers,
+    Object? body,
+    Encoding? encoding,
+  }) => _sendUnstreamed('PATCH', url, headers, body, encoding);
+
+  @override
+  Future<http.Response> delete(
+    Uri url, {
+    Map<String, String>? headers,
+    Object? body,
+    Encoding? encoding,
+  }) => _sendUnstreamed('DELETE', url, headers, body, encoding);
+
+  Future<http.Response> _sendUnstreamed(
+    String method,
+    Uri url,
+    Map<String, String>? headers,
+    Object? body,
+    Encoding? encoding, {
+    bool skipUserValidation = false,
+  }) async {
+    url = _validate(url, skipUserValidation: skipUserValidation);
+    if (!skipUserValidation) url = addAppToUrl(url);
+    var request = http.Request(method, url);
+
+    if (headers != null) request.headers.addAll(headers);
+    if (encoding != null) request.encoding = encoding;
+    if (body != null) {
+      if (body is String) {
+        request.body = body;
+      } else if (body is List) {
+        request.bodyBytes = body.cast<int>();
+      } else if (body is Map) {
+        request.bodyFields = body.cast<String, String>();
+      } else {
+        throw ArgumentError('Invalid request body "$body".');
+      }
+    }
+
+    return http.Response.fromStream(
+      await send(request, skipUserValidation: skipUserValidation),
+    );
+  }
+
+  Map<String, String> authHeaders() {
+    var headers = <String, String>{};
+    headers.addAll({
+      'uid': user!.uid!,
+      'access-token': user!.accessToken!,
+      'client': user!.client!,
+    });
+    headers['content-type'] = 'application/json';
+    headers['accept'] = 'application/json';
+    return headers;
+  }
+
+  void handleResponse(http.Response response) {
+    var headers = response.headers;
+    String? accessToken = headers['access-token'];
+    if (accessToken == "") return;
+    authManager.user!.accessToken = accessToken;
+    authManager.user!.client = headers['client'];
+    authManager.user!.uid = headers['uid'];
+    authManager.writeKeysToStore();
+  }
+
+  User? handleUserResponse(http.Response response) {
+    if (response.statusCode != 200) {
+      throw Exception('Failed to login');
+    }
+    var respHeaders = response.headers;
+    var body = json.decode(response.body);
+    authManager.user = User(
+      accessToken: respHeaders['access-token'],
+      client: respHeaders['client'],
+      uid: respHeaders['uid'],
+      appId: body["data"][config.appIdKey],
+      id: body["data"]['id'],
+      email: body["data"]['email'],
+      name: body["data"]['name'],
+    );
+    authManager.writeKeysToStore();
+    return user;
+  }
+
+  Uri _validate(Uri uri, {bool skipUserValidation = false}) {
+    if (uri.host != config.appURL) {
+      uri = uri.replace(host: config.appURL);
+    }
+    if (!skipUserValidation) userMustBeLoggedIn();
+    return uri;
+  }
+
+  User? get user => authManager.user;
+
+  bool userMustBeLoggedIn() {
+    if (user == null || user!.accessToken == null) {
+      throw Exception('User not logged in');
+    }
+    return true;
+  }
+
+  Uri addAppToUrl(Uri url, {Map<String, dynamic>? queryParams}) {
+    final Map<String, String> paramsToAdd = {};
+    if (queryParams != null) {
+      queryParams.forEach((key, value) {
+        paramsToAdd[key] = value.toString();
+      });
+    }
+    paramsToAdd[config.appIdKey] = user!.appId!.toString();
+    return url.replace(queryParameters: paramsToAdd);
+  }
+
+  static const Map<String, String> defaultHeaders = {
+    'content-type': 'application/json',
+    'accept': 'application/json',
+  };
+}

--- a/lib/src/response.dart
+++ b/lib/src/response.dart
@@ -2,16 +2,7 @@ import 'dart:convert';
 
 import 'package:http/http.dart' as http;
 
-class Response {
-  Response({required this.body, required this.statusCode});
-
-  factory Response.fromHttpResponse(http.Response response) {
-    return Response(body: response.body, statusCode: response.statusCode);
-  }
-
-  int statusCode;
-  String body;
-
+extension ResponseExtension on http.Response {
   bool get success => statusCode >= 200 && statusCode <= 299;
 
   dynamic get jsonBody => json.decode(body);

--- a/lib/src/test_helpers/fake_auth_manager.dart
+++ b/lib/src/test_helpers/fake_auth_manager.dart
@@ -1,12 +1,23 @@
+import 'package:flutter_token_auth/src/client.dart';
 import 'package:http/http.dart' as http;
 import 'package:flutter_token_auth/flutter_token_auth.dart';
+import 'package:http/testing.dart';
 
 import 'method_counters.dart';
 
 class FakeAuthManager implements AuthManager {
   static final FakeAuthManager _authManager = FakeAuthManager._new();
+
   @override
-  late AuthConfig config;
+  AuthConfig config = const AuthConfig(appURL: 'https://example.test');
+
+  @override
+  AuthClient httpClient = AuthClient(
+    config: const AuthConfig(appURL: 'https://example.test'),
+    httpClient: MockClient((request) async {
+      return http.Response('{}', 200);
+    }),
+  );
 
   FakeAuthManager._new();
 
@@ -46,11 +57,6 @@ class FakeAuthManager implements AuthManager {
   }
 
   @override
-  Uri addAppToUrl(Uri url, {Map<String, dynamic>? queryParams}) {
-    throw UnimplementedError();
-  }
-
-  @override
   Future<bool> checkLoggedIn() async {
     if (allowLogin) {
       if (user == null) return false;
@@ -63,16 +69,11 @@ class FakeAuthManager implements AuthManager {
   get currentUser => user;
 
   @override
-  Future<Response> get(
+  Future<http.Response> get(
     Uri url, {
     Map<String, String>? headers,
     Map<String, dynamic>? queryParams,
   }) {
-    throw UnimplementedError();
-  }
-
-  @override
-  handleResponse(http.Response response) {
     throw UnimplementedError();
   }
 
@@ -93,7 +94,7 @@ class FakeAuthManager implements AuthManager {
   }
 
   @override
-  Future<Response> post(
+  Future<http.Response> post(
     Uri url, {
     Map<String, String>? headers,
     Map<String, Object?>? body,
@@ -115,12 +116,7 @@ class FakeAuthManager implements AuthManager {
   }
 
   @override
-  Map<String, String> buildHeaders(headers) {
-    throw UnimplementedError();
-  }
-
-  @override
-  Future<Response> put(
+  Future<http.Response> put(
     Uri url, {
     Map<String, String>? headers,
     Map<String, Object?>? body,
@@ -129,15 +125,7 @@ class FakeAuthManager implements AuthManager {
   }
 
   @override
-  bool userMustBeLoggedIn() {
-    if (allowLogin) {
-      return user != null && user!.isSignedIn;
-    }
-    throw UnimplementedError();
-  }
-
-  @override
-  Future<Response> delete(
+  Future<http.Response> delete(
     Uri url, {
     Map<String, String>? headers,
     Map<String, Object?>? body,
@@ -166,11 +154,6 @@ class FakeAuthManager implements AuthManager {
       user = MockUser.create(email: email, name: name);
       return user;
     }
-    throw UnimplementedError();
-  }
-
-  @override
-  User? handleUserResponse(http.Response response) {
     throw UnimplementedError();
   }
 

--- a/lib/src/test_helpers/fake_auth_manager.dart
+++ b/lib/src/test_helpers/fake_auth_manager.dart
@@ -35,6 +35,7 @@ class FakeAuthManager implements AuthManager {
     return _authManager;
   }
 
+  @override
   User? user;
 
   bool allowLogin = false;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_token_auth
 description: A package for handling token-based authentication in Flutter.
-version: 0.2.4
+version: 0.3.0
 repository: https://github.com/diarmuidr3d/flutter_token_auth
 
 environment:

--- a/test/auth_client_test.dart
+++ b/test/auth_client_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_token_auth/flutter_token_auth.dart';
+import 'package:flutter_token_auth/src/client.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+void main() {
+  final config = AuthConfig(appURL: 'https://example.test');
+  final httpClient = MockClient((request) async {
+    return http.Response('{}', 200);
+  });
+  late User user;
+
+  group('AuthClient', () {
+    late AuthClient client;
+    setUp(() {
+      user = MockUser.create();
+      client = AuthClient(config: config);
+    });
+    group('headers', () {
+      test('should have correct default headers', () {
+        expect(
+          AuthClient.defaultHeaders['content-type'],
+          equals('application/json'),
+        );
+        expect(AuthClient.defaultHeaders['accept'], equals('application/json'));
+      });
+    });
+
+    group('with logged in user', () {
+      setUp(() {
+        client.authManager.user = user;
+      });
+
+      group('addAppToUrl', () {
+        test('should add app id to url', () async {
+          final url = Uri.parse('https://test.example.com/auth/sign_in');
+          final newUrl = client.addAppToUrl(url);
+          expect(
+            newUrl.queryParameters['app_id'],
+            equals(user.appId.toString()),
+          );
+        });
+      });
+    });
+  });
+}

--- a/test/auth_client_test.dart
+++ b/test/auth_client_test.dart
@@ -15,7 +15,7 @@ void main() {
     late AuthClient client;
     setUp(() {
       user = MockUser.create();
-      client = AuthClient(config: config);
+      client = AuthClient(config: config, httpClient: httpClient);
     });
     group('headers', () {
       test('should have correct default headers', () {

--- a/test/response_test.dart
+++ b/test/response_test.dart
@@ -1,10 +1,11 @@
+import 'package:http/http.dart' as http;
 import 'package:test/test.dart';
 import 'package:flutter_token_auth/flutter_token_auth.dart';
 
 void main() {
   group('Response Class Testing', () {
     test('should create Response from data', () {
-      final response = Response(body: '{"test": true}', statusCode: 200);
+      final response = http.Response('{"test": true}', 200);
 
       expect(response.statusCode, equals(200));
       expect(response.body, equals('{"test": true}'));
@@ -13,8 +14,8 @@ void main() {
     });
 
     test('should handle different status codes', () {
-      final successResponse = Response(body: '{}', statusCode: 201);
-      final errorResponse = Response(body: 'Error', statusCode: 400);
+      final successResponse = http.Response('{}', 201);
+      final errorResponse = http.Response('Error', 400);
 
       expect(successResponse.success, isTrue);
       expect(errorResponse.success, isFalse);

--- a/test/test_helper_tests/fake_auth_manager_test.dart
+++ b/test/test_helper_tests/fake_auth_manager_test.dart
@@ -63,12 +63,6 @@ void main() {
       expect(isLoggedIn, isTrue);
     });
 
-    test('should handle userMustBeLoggedIn with FakeAuthManager', () {
-      final fakeAuth = FakeAuthManager(withLoggedInUser: true);
-
-      expect(fakeAuth.userMustBeLoggedIn(), isTrue);
-    });
-
     test('should handle failed login attempts', () async {
       expect(
         () => fakeAuth.login('test@example.com', 'wrongpassword'),


### PR DESCRIPTION
Adds `AuthClient` which can be used in place of `http.BaseClient` and provides a more easily migrateable way to adopt the flutter token auth.